### PR TITLE
Remove references to group:wood_slab

### DIFF
--- a/lrfurn/armchairs.lua
+++ b/lrfurn/armchairs.lua
@@ -63,15 +63,6 @@ for i in ipairs(armchairs_list) do
 		}
 	})
 
-	minetest.register_craft({
-		output = "lrfurn:armchair_"..colour,
-		recipe = {
-			{"wool:"..colour, "", "", },
-			{"group:wood_slab", "", "", },
-			{"group:stick", "", "", }
-		}
-	})
-
 end
 
 if minetest.setting_get("log_mods") then

--- a/lrfurn/coffeetable.lua
+++ b/lrfurn/coffeetable.lua
@@ -119,15 +119,6 @@ minetest.register_craft({
 	}
 })
 
-minetest.register_craft({
-	output = "lrfurn:coffeetable",
-	recipe = {
-		{"", "", "", },
-		{"group:wood_slab", "group:wood_slab", "group:wood_slab", },
-		{"group:stick", "", "group:stick", }
-	}
-})
-
 if minetest.setting_get("log_mods") then
 	minetest.log("action", "coffeetable loaded")
 end

--- a/lrfurn/endtable.lua
+++ b/lrfurn/endtable.lua
@@ -45,15 +45,6 @@ minetest.register_craft({
 	}
 })
 
-minetest.register_craft({
-	output = "lrfurn:endtable",
-	recipe = {
-		{"", "", "", },
-		{"group:wood_slab", "group:wood_slab", "", },
-		{"group:stick", "group:stick", "", }
-	}
-})
-
 if minetest.setting_get("log_mods") then
 	minetest.log("action", "endtable loaded")
 end

--- a/lrfurn/longsofas.lua
+++ b/lrfurn/longsofas.lua
@@ -89,15 +89,6 @@ for i in ipairs(longsofas_list) do
 		}
 	})
 
-	minetest.register_craft({
-		output = "lrfurn:longsofa_"..colour,
-		recipe = {
-			{"wool:"..colour, "wool:"..colour, "wool:"..colour, },
-			{"group:wood_slab", "group:wood_slab", "group:wood_slab", },
-			{"group:stick", "group:stick", "group:stick", }
-		}
-	})
-
 end
 
 if minetest.setting_get("log_mods") then

--- a/lrfurn/sofas.lua
+++ b/lrfurn/sofas.lua
@@ -89,15 +89,6 @@ for i in ipairs(sofas_list) do
 		}
 	})
 
-	minetest.register_craft({
-		output = "lrfurn:sofa_"..colour,
-		recipe = {
-			{"wool:"..colour, "wool:"..colour, "", },
-			{"group:wood_slab", "group:wood_slab", "", },
-			{"group:stick", "group:stick", "", }
-		}
-	})
-
 end
 
 if minetest.setting_get("log_mods") then


### PR DESCRIPTION
`group:wood_slab` is not created by `stairs` or `stairsplus` and I can't find any nodes which utilise that group.