### PR TITLE
Drop item when dug, abm issue

### DIFF
--- a/itemframes/init.lua
+++ b/itemframes/init.lua
@@ -139,7 +139,13 @@ minetest.register_node("itemframes:frame",{
 		local meta = minetest.get_meta(pos)
 		return player:get_player_name() == meta:get_string("owner")
 	end,
-	after_destruct = remove_item,
+	on_destruct = function(pos)
+		local meta = minetest.get_meta(pos)
+		local node = minetest.get_node(pos)
+		if meta:get_string("item") ~= "" then
+			drop_item(pos, node)
+		end
+	end,
 })
 
 
@@ -185,7 +191,13 @@ minetest.register_node("itemframes:pedestal",{
 		local meta = minetest.get_meta(pos)
 		return player:get_player_name() == meta:get_string("owner")
 	end,
-	after_destruct = remove_item,
+	on_destruct = function(pos)
+		local meta = minetest.get_meta(pos)
+		local node = minetest.get_node(pos)
+		if meta:get_string("item") ~= "" then
+			drop_item(pos, node)
+		end
+	end,
 })
 
 -- automatically restore entities lost from frames/pedestals
@@ -196,7 +208,17 @@ minetest.register_abm({
 	interval = 15,
 	chance = 1,
 	action = function(pos, node, active_object_count, active_object_count_wider)
-		if #minetest.get_objects_inside_radius(pos, 0.5) > 0 then return end
+		local num
+
+		if node.name == "itemframes:frame" then
+			num = #minetest.get_objects_inside_radius(pos, 0.5)
+		elseif node.name == "itemframes:pedestal" then
+			pos.y = pos.y + 1
+			num = #minetest.get_objects_inside_radius(pos, 0.5)
+			pos.y = pos.y - 1
+		end
+
+		if num > 0 then return end
 		update_item(pos, node)
 	end
 })


### PR DESCRIPTION
A quick edit to drop items from an itemframe or pedestal when dug instead of removing them, also a fix for the abm to update pedestals properly...