### PR TITLE
Expansion placeholders and fixes

### DIFF
--- a/homedecor/clocks.lua
+++ b/homedecor/clocks.lua
@@ -91,7 +91,7 @@ homedecor.register("grandfather_clock", {
 	selection_box = gf_cbox,
 	collision_box = gf_cbox,
 	sounds = default.node_sound_wood_defaults(),
-	expand = { top="air" },
+	expand = { top="placeholder" },
 	on_rotate = screwdriver.rotate_simple
 })
 

--- a/homedecor/doors_and_gates.lua
+++ b/homedecor/doors_and_gates.lua
@@ -604,21 +604,18 @@ homedecor.register("door_japanese_closed", {
 		type = "fixed",
 		fixed = {-0.5, -0.5, -0.0625, 0.5, 1.5, 0},
 	},
-	expand = { top = "air" },
+	expand = { top = "placeholder" },
 	on_rightclick = function(pos, node, clicker)
 		minetest.set_node(pos, {name = "homedecor:door_japanese_open", param2 = node.param2})
 	end
 })
 
-minetest.register_node("homedecor:door_japanese_open", {
+homedecor.register("door_japanese_open", {
 	tiles = {
 		"homedecor_generic_wood_luxury.png",
 		"homedecor_japanese_paper.png"
 	},
-	drawtype = "mesh",
 	mesh = "homedecor_door_japanese_open.obj",
-	paramtype = "light",
-	paramtype2 = "facedir",
 	groups = { snappy = 3, not_in_creative_inventory = 1 },
 	sounds = default.node_sound_wood_defaults(),
 	on_rotate = screwdriver.disallow,
@@ -630,6 +627,7 @@ minetest.register_node("homedecor:door_japanese_open", {
 		type = "fixed",
 		fixed = {-1.5, -0.5, -0.0625, -0.5, 1.5, 0},
 	},
+	expand = { top = "placeholder" },
 	on_rightclick = function(pos, node, clicker)
 		minetest.set_node(pos, {name = "homedecor:door_japanese_closed", param2 = node.param2})
 	end,

--- a/homedecor/exterior.lua
+++ b/homedecor/exterior.lua
@@ -25,6 +25,7 @@ homedecor.register("barbecue", {
 	selection_box = bbq_cbox,
 	collision_box = bbq_cbox,
 	sounds = default.node_sound_stone_defaults(),
+	-- no need for placeholder it appears
 	expand = { top="air" },
 })
 
@@ -52,7 +53,7 @@ homedecor.register("bench_large_1", {
 	description = "Garden Bench (style 1)",
 	inventory_image = "homedecor_bench_large_1_inv.png",
 	groups = { snappy = 3 },
-	expand = { right="air" },
+	expand = { right="placeholder" },
 	sounds = default.node_sound_wood_defaults(),
 	selection_box = bl1_sbox,
 	node_box = bl1_cbox,
@@ -83,7 +84,7 @@ homedecor.register("bench_large_2", {
 	groups = {snappy=3},
 	selection_box = bl2_sbox,
 	node_box = bl2_cbox,
-	expand = { right="air" },
+	expand = { right="placeholder" },
 	sounds = default.node_sound_wood_defaults(),
 	on_rotate = screwdriver.disallow
 })
@@ -101,7 +102,7 @@ homedecor.register("deckchair", {
 	tiles = {"homedecor_deckchair.png"},
 	description = "Deck Chair",
 	groups = { snappy = 3 },
-	expand = { forward="air" },
+	expand = { forward="placeholder" },
 	sounds = default.node_sound_wood_defaults(),
 	selection_box = dc_cbox,
 	collision_box = dc_cbox,
@@ -116,7 +117,7 @@ homedecor.register("deckchair_striped_blue", {
 	tiles = {"homedecor_deckchair_striped_blue.png"},
 	description = "Deck Chair",
 	groups = { snappy = 3 },
-	expand = { forward="air" },
+	expand = { forward="placeholder" },
 	sounds = default.node_sound_wood_defaults(),
 	selection_box = dc_cbox,
 	collision_box = dc_cbox,
@@ -135,7 +136,7 @@ homedecor.register("doghouse", {
 	selection_box = homedecor.nodebox.slab_y(1.5),
 	collision_box = homedecor.nodebox.slab_y(1.5),
 	groups = {snappy=3},
-	expand = { top="air" },
+	expand = { top="placeholder" },
 	sounds = default.node_sound_wood_defaults(),
 	on_rotate = screwdriver.rotate_simple
 })
@@ -323,7 +324,7 @@ homedecor.register("well", {
 	groups = { snappy = 3 },
 	selection_box = homedecor.nodebox.slab_y(2),
 	collision_box = homedecor.nodebox.slab_y(2),
-	expand = { top="air" },
+	expand = { top="placeholder" },
 	sounds = default.node_sound_stone_defaults(),
 	on_rotate = screwdriver.rotate_simple
 })

--- a/homedecor/foyer.lua
+++ b/homedecor/foyer.lua
@@ -32,7 +32,7 @@ homedecor.register("coat_tree", {
 	description = "Coat tree",
 	groups = {snappy=3},
 	sounds = default.node_sound_wood_defaults(),
-	expand = { top="air" },
+	expand = { top="placeholder" },
 	walkable = false,
 	selection_box = {
 		type = "fixed",

--- a/homedecor/gastronomy.lua
+++ b/homedecor/gastronomy.lua
@@ -185,7 +185,7 @@ homedecor.register("soda_machine", {
 	groups = {snappy=3},
 	selection_box = svm_cbox,
 	collision_box = svm_cbox,
-	expand = { top="air" },
+	expand = { top="placeholder" },
 	sounds = default.node_sound_wood_defaults(),
 	on_rotate = screwdriver.rotate_simple,
 	on_punch = function(pos, node, puncher, pointed_thing)

--- a/homedecor/handlers/expansion.lua
+++ b/homedecor/handlers/expansion.lua
@@ -51,25 +51,22 @@ local function select_node(pointed_thing)
 	return def and pos, def
 end
 
---- check if 2 given nodes can and may be build to a place
-local function is_buildable_to(placer_name, pos, def, pos2)
-	if not def then
+--- check if all nodes can and may be build to
+local function is_buildable_to(placer_name, ...)
+	for _, pos in ipairs({...}) do
 		local node = minetest.get_node_or_nil(pos)
-		def = node and minetest.registered_nodes[node.name]
+		local def = node and minetest.registered_nodes[node.name]
+		if not (def and def.buildable_to) or minetest.is_protected(pos, placer_name) then
+			return false
+		end
 	end
-
-	local node = minetest.get_node_or_nil(pos2)
-	local def2 = node and minetest.registered_nodes[node.name]
-
-	return def and def.buildable_to and def2 and def2.buildable_to
-		and not minetest.is_protected(pos, placer_name)
-		and not minetest.is_protected(pos2, placer_name)
+	return true
 end
 
 -- place one or two nodes if and only if both can be placed
 local function stack(itemstack, placer, fdir, pos, def, pos2, node1, node2)
 	local placer_name = placer:get_player_name() or ""
-	if is_buildable_to(placer_name, pos, def, pos2) then
+	if is_buildable_to(placer_name, pos, pos2) then
 		local fdir = fdir or minetest.dir_to_facedir(placer:get_look_dir())
 		minetest.set_node(pos, { name = node1, param2 = fdir })
 		node2 = node2 or "air" -- this can be used to clear buildable_to nodes even though we are using a multinode mesh
@@ -291,12 +288,12 @@ function homedecor.place_banister(itemstack, placer, pointed_thing)
 	-- try to place a diagonal one on the side of blocks stacked like stairs
 	-- or follow an existing diagonal with another.
 	if (left_below_node and string.find(left_below_node.name, "banister_.-_diagonal_right")
-	  and below_node and is_buildable_to(placer_name, below_pos, nil, below_pos))
-	  or not is_buildable_to(placer_name, right_fwd_above_pos, nil, right_fwd_above_pos) then
+	  and below_node and is_buildable_to(placer_name, below_pos, below_pos))
+	  or not is_buildable_to(placer_name, right_fwd_above_pos, right_fwd_above_pos) then
 		new_place_name = string.gsub(new_place_name, "_horizontal", "_diagonal_right")
 	elseif (right_below_node and string.find(right_below_node.name, "banister_.-_diagonal_left")
-	  and below_node and is_buildable_to(placer_name, below_pos, nil, below_pos))
-	  or not is_buildable_to(placer_name, left_fwd_above_pos, nil, left_fwd_above_pos) then
+	  and below_node and is_buildable_to(placer_name, below_pos, below_pos))
+	  or not is_buildable_to(placer_name, left_fwd_above_pos, left_fwd_above_pos) then
 		new_place_name = string.gsub(new_place_name, "_horizontal", "_diagonal_left")
 
 	-- try to follow a diagonal with the corresponding horizontal
@@ -310,12 +307,12 @@ function homedecor.place_banister(itemstack, placer, pointed_thing)
 
 	-- try to place a horizontal in-line with the nearest diagonal, at the top
 	elseif left_fwd_below_node and string.find(left_fwd_below_node.name, "homedecor:banister_.*_diagonal")
-	  and is_buildable_to(placer_name, fwd_pos, nil, fwd_pos) then	
+	  and is_buildable_to(placer_name, fwd_pos, fwd_pos) then
 		fdir = left_fwd_below_node.param2
 		pos = fwd_pos
 		new_place_name = string.gsub(left_fwd_below_node.name, "_diagonal_.-$", "_horizontal")
 	elseif right_fwd_below_node and string.find(right_fwd_below_node.name, "homedecor:banister_.*_diagonal")
-	  and is_buildable_to(placer_name, fwd_pos, nil, fwd_pos) then	
+	  and is_buildable_to(placer_name, fwd_pos, fwd_pos) then
 		fdir = right_fwd_below_node.param2
 		pos = fwd_pos
 		new_place_name = string.gsub(right_fwd_below_node.name, "_diagonal_.-$", "_horizontal")
@@ -330,12 +327,12 @@ function homedecor.place_banister(itemstack, placer, pointed_thing)
 
 	-- try to place a horizontal in-line with the nearest diagonal, at the bottom
 	elseif left_fwd_node and string.find(left_fwd_node.name, "homedecor:banister_.*_diagonal") 
-	  and is_buildable_to(placer_name, fwd_pos, nil, fwd_pos) then	
+	  and is_buildable_to(placer_name, fwd_pos, fwd_pos) then
 		fdir = left_fwd_node.param2
 		pos = fwd_pos
 		new_place_name = string.gsub(left_fwd_node.name, "_diagonal_.-$", "_horizontal")
 	elseif right_fwd_node and string.find(right_fwd_node.name, "homedecor:banister_.*_diagonal")
-	  and is_buildable_to(placer_name, fwd_pos, nil, fwd_pos) then	
+	  and is_buildable_to(placer_name, fwd_pos, fwd_pos) then
 		fdir = right_fwd_node.param2
 		pos = fwd_pos
 		new_place_name = string.gsub(right_fwd_node.name, "_diagonal_.-$", "_horizontal")

--- a/homedecor/handlers/expansion.lua
+++ b/homedecor/handlers/expansion.lua
@@ -23,6 +23,19 @@ homedecor.fdir_to_fwd = {
 	{ -1,  0 },
 }
 
+local placeholder_node = "homedecor:expansion_placeholder"
+minetest.register_node(placeholder_node, {
+	description = "Expansion placeholder (you hacker you!)",
+	groups = { not_in_creative_inventory=1 },
+	drawtype = "airlike",
+	paramtype = "light",
+	walkable = false,
+	selection_box = { type = "fixed", fixed = { 0, 0, 0, 0, 0, 0 } },
+	is_ground_content = false,
+	sunlight_propagates = true,
+	buildable_to = false,
+})
+
 -- selects which node was pointed at based on it being known, and either clickable or buildable_to
 local function select_node(pointed_thing)
 	local pos = pointed_thing.under
@@ -52,7 +65,13 @@ local function stack(itemstack, placer, fdir, pos, def, pos2, node1, node2)
 		local fdir = fdir or minetest.dir_to_facedir(placer:get_look_dir())
 		minetest.set_node(pos, { name = node1, param2 = fdir })
 		node2 = node2 or "air" -- this can be used to clear buildable_to nodes even though we are using a multinode mesh
-		minetest.set_node(pos2, { name = node2, param2 = (node2 ~= "air" and fdir) or nil })
+		-- do not assume by default, as we still might want to allow overlapping in some cases
+		local has_facedir = node2 ~= "air"
+		if node2 == "placeholder" then
+			has_facedir = false
+			node2 = placeholder_node
+		end
+		minetest.set_node(pos2, { name = node2, param2 = (has_facedir and fdir) or nil })
 
 		-- call after_place_node of the placed node if available
 		local ctrl_node_def = minetest.registered_nodes[node1]

--- a/homedecor/handlers/registration.lua
+++ b/homedecor/handlers/registration.lua
@@ -41,6 +41,12 @@ function homedecor.register(name, original_def)
 	def.after_unexpand = nil
 
 	if expand then
+		-- dissallow rotating only half the expanded node by default
+		-- unless we know better
+		def.on_rotate = def.on_rotate
+			or (def.mesh and expand.top and screwdriver.rotate_simple)
+			or screwdriver.disallow
+
 		def.on_place = def.on_place or function(itemstack, placer, pointed_thing)
 			if expand.top then
 				return homedecor.stack_vertically(itemstack, placer, pointed_thing, itemstack:get_name(), expand.top)

--- a/homedecor/handlers/registration.lua
+++ b/homedecor/handlers/registration.lua
@@ -1,5 +1,6 @@
 homedecor = homedecor or {}
 local S = homedecor.gettext
+local placeholder_node = "homedecor:expansion_placeholder"
 
 --wrapper around minetest.register_node that sets sane defaults and interprets some specialized settings
 function homedecor.register(name, original_def)
@@ -59,7 +60,8 @@ function homedecor.register(name, original_def)
 		def.after_dig_node = def.after_dig_node or function(pos, oldnode, oldmetadata, digger)
 			if expand.top and expand.forward ~= "air" then
 				local top_pos = { x=pos.x, y=pos.y+1, z=pos.z }
-				if minetest.get_node(top_pos).name == expand.top then
+				local node = minetest.get_node(top_pos).name
+				if node == expand.top or node == placeholder_node then
 					minetest.remove_node(top_pos)
 				end
 			end
@@ -69,13 +71,15 @@ function homedecor.register(name, original_def)
 
 			if expand.right and expand.forward ~= "air" then
 				local right_pos = { x=pos.x+homedecor.fdir_to_right[fdir+1][1], y=pos.y, z=pos.z+homedecor.fdir_to_right[fdir+1][2] }
-				if minetest.get_node(right_pos).name == expand.right then
+				local node = minetest.get_node(right_pos).name
+				if node == expand.right or node == placeholder_node then
 					minetest.remove_node(right_pos)
 				end
 			end
 			if expand.forward and expand.forward ~= "air" then
 				local forward_pos = { x=pos.x+homedecor.fdir_to_fwd[fdir+1][1], y=pos.y, z=pos.z+homedecor.fdir_to_fwd[fdir+1][2] }
-				if minetest.get_node(forward_pos).name == expand.forward then
+				local node = minetest.get_node(forward_pos).name
+				if node == expand.forward or node == placeholder_node then
 					minetest.remove_node(forward_pos)
 				end
 			end

--- a/homedecor/kitchen_appliances.lua
+++ b/homedecor/kitchen_appliances.lua
@@ -12,7 +12,7 @@ homedecor.register("refrigerator_steel", {
 	sounds = default.node_sound_stone_defaults(),
 	selection_box = homedecor.nodebox.slab_y(2),
 	collision_box = homedecor.nodebox.slab_y(2),
-	expand = { top="air" },
+	expand = { top="placeholder" },
 	infotext=S("Refrigerator"),
 	inventory = {
 		size=50,
@@ -31,7 +31,7 @@ homedecor.register("refrigerator_white", {
 	selection_box = homedecor.nodebox.slab_y(2),
 	collision_box = homedecor.nodebox.slab_y(2),
 	sounds = default.node_sound_stone_defaults(),
-	expand = { top="air" },
+	expand = { top="placeholder" },
 	infotext=S("Refrigerator"),
 	inventory = {
 		size=50,

--- a/homedecor/laundry.lua
+++ b/homedecor/laundry.lua
@@ -54,7 +54,7 @@ homedecor.register("ironing_board", {
 		"wool_grey.png",
 		"homedecor_generic_metal_black.png^[brighten"
 	},
-	expand = {right = "air"},
+	expand = {right = "placeholder"},
 	groups = { snappy = 3 },
 	selection_box = ib_cbox,
 	collision_box = ib_cbox

--- a/homedecor/lighting.lua
+++ b/homedecor/lighting.lua
@@ -477,7 +477,7 @@ local function reg_lamp(suffix, nxt, tilesuffix, light, color)
 			node.name = "homedecor:standing_lamp"..lampcolor.."_"..repl[suffix]
 			minetest.set_node(pos, node)
 		end,
-		expand = { top="air" },
+		expand = { top="placeholder" },
 	})
 
 	minetest.register_alias("homedecor:standing_lamp_bottom"..lampcolor.."_"..suffix, "homedecor:standing_lamp"..lampcolor.."_"..suffix)

--- a/homedecor/misc-nodes.lua
+++ b/homedecor/misc-nodes.lua
@@ -273,7 +273,7 @@ homedecor.register("pool_table", {
 	groups = {snappy=3},
 	selection_box = pooltable_cbox,
 	collision_box = pooltable_cbox,
-	expand = { forward="air" },
+	expand = { forward="placeholder" },
 	sounds = default.node_sound_wood_defaults(),
 	on_rotate = screwdriver.disallow
 })
@@ -297,7 +297,7 @@ homedecor.register("piano", {
 	groups = { snappy = 3 },
 	selection_box = piano_cbox,
 	collision_box = piano_cbox,
-	expand = { right="air" },
+	expand = { right="placeholder" },
 	sounds = default.node_sound_wood_defaults(),
 	on_rotate = screwdriver.disallow
 })
@@ -377,7 +377,7 @@ homedecor.register("tool_cabinet", {
 	on_rotate = screwdriver.rotate_simple,
 	groups = { snappy=3 },
 	selection_box = homedecor.nodebox.slab_y(2),
-	expand = { top="air" },
+	expand = { top="placeholder" },
 	inventory = {
 		size=24,
 	}

--- a/homedecor/office.lua
+++ b/homedecor/office.lua
@@ -34,7 +34,7 @@ homedecor.register("desk", {
 	collision_box = desk_cbox,
 	sounds = default.node_sound_wood_defaults(),
 	groups = { snappy = 3 },
-	expand = { right="air" },
+	expand = { right="placeholder" },
 	inventory = {
 		size=24,
 		lockable=true,
@@ -112,7 +112,7 @@ for _, c in pairs({"basic", "upscale"}) do
 		sounds = default.node_sound_wood_defaults(),
 		selection_box = ofchairs_sbox,
 		collision_box = ofchairs_cbox,
-		expand = { top = "air" },
+		expand = { top = "placeholder" },
 		on_rotate = screwdriver.rotate_simple
 	})
 end

--- a/homedecor/wardrobe.lua
+++ b/homedecor/wardrobe.lua
@@ -18,7 +18,7 @@ homedecor.register("wardrobe", {
 	selection_box = wd_cbox,
 	collision_box = wd_cbox,
 	sounds = default.node_sound_wood_defaults(),
-	expand = { top="air" },
+	expand = { top="placeholder" },
 	on_rotate = screwdriver.rotate_simple,
 	infotext = "Wardrobe",
 	inventory = {


### PR DESCRIPTION
Fix for the long standing issue of expansion code not protecting the expanded space against building. (recently mentioned in #292)

"air" as expansion keyword was left to allow for exceptions (like the barbecue grill)

Most nodes have been updated to make use of the new "placeholder" keyword.
But some with custom placement code will probably need their own set of fixes (staircases, beds, doors) or a rewrite to make use of the registration system instead.

It also fixes:
* some odd behavior during right clicking things with the expansion nodes in your wielding hand, which only worked in the right combinations
* content_ignore not being checked for
* #205 regression for banisters
* replacement of unknown nodes, when placing through occupied nodes